### PR TITLE
fixed clone rotation and scale cloning

### DIFF
--- a/src/rajawali/Object3D.java
+++ b/src/rajawali/Object3D.java
@@ -649,8 +649,8 @@ public class Object3D extends ATransformable3D implements Comparable<Object3D>, 
 	public Object3D clone(boolean copyMaterial, boolean cloneChildren) {
 		Object3D clone = new Object3D();
 		cloneTo(clone, copyMaterial);
-		clone.setRotation(getRotation());
-		clone.setScale(getScale());
+        clone.setRotation(getRotation().clone());
+        clone.setScale(getScale().clone());
 		
 		if(cloneChildren)
 		{


### PR DESCRIPTION
When cloning an Object3D the rotation and scale became pointers to the
original object, causing scaling or rotating an object to influence the
source and all other clones of that source object