### PR TITLE
Adds a new render frame callback system

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,16 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0" is_locked="false">
+    <option name="myName" value="Project Default" />
+    <option name="myLocal" value="false" />
+    <inspection_tool class="LoggerInitializedWithForeignClass" enabled="false" level="WARNING" enabled_by_default="false">
+      <option name="loggerClassName" value="org.apache.log4j.Logger,org.slf4j.LoggerFactory,org.apache.commons.logging.LogFactory,java.util.logging.Logger" />
+      <option name="loggerFactoryMethodName" value="getLogger,getLogger,getLog,getLogger" />
+    </inspection_tool>
+    <inspection_tool class="UnusedDeclaration" enabled="false" level="WARNING" enabled_by_default="false">
+      <option name="ADD_MAINS_TO_ENTRIES" value="true" />
+      <option name="ADD_APPLET_TO_ENTRIES" value="true" />
+      <option name="ADD_SERVLET_TO_ENTRIES" value="true" />
+      <option name="ADD_NONJAVA_TO_ENTRIES" value="true" />
+    </inspection_tool>
+  </profile>
+</component>

--- a/.idea/inspectionProfiles/profiles_settings.xml
+++ b/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,0 +1,7 @@
+<component name="InspectionProjectProfileManager">
+  <settings>
+    <option name="PROJECT_PROFILE" value="Project Default" />
+    <option name="USE_PROJECT_PROFILE" value="true" />
+    <version value="1.0" />
+  </settings>
+</component>

--- a/rajawali/src/main/java/rajawali/postprocessing/APass.java
+++ b/rajawali/src/main/java/rajawali/postprocessing/APass.java
@@ -58,7 +58,7 @@ public abstract class APass implements IPass {
 	}
 	
 	public abstract void render(RajawaliScene scene, RajawaliRenderer renderer, ScreenQuad screenQuad,
-			RenderTarget writeTarget, RenderTarget readTarget, double deltaTime);
+			RenderTarget writeTarget, RenderTarget readTarget, long ellapsedTime, double deltaTime);
 
 	public PassType getPassType() {
 		return mPassType;

--- a/rajawali/src/main/java/rajawali/postprocessing/IPass.java
+++ b/rajawali/src/main/java/rajawali/postprocessing/IPass.java
@@ -26,7 +26,7 @@ public interface IPass extends IPostProcessingComponent {
 	
 	boolean isClear();
 	boolean needsSwap();
-	void render(RajawaliScene scene, RajawaliRenderer renderer, ScreenQuad screenQuad, RenderTarget writeTarget, RenderTarget readTarget, double deltaTime);
+	void render(RajawaliScene scene, RajawaliRenderer renderer, ScreenQuad screenQuad, RenderTarget writeTarget, RenderTarget readTarget, long ellapsedTime, double deltaTime);
 	PassType getPassType();
 	void setMaterial(Material material);
 	void setRenderToScreen(boolean renderToScreen);

--- a/rajawali/src/main/java/rajawali/postprocessing/PostProcessingManager.java
+++ b/rajawali/src/main/java/rajawali/postprocessing/PostProcessingManager.java
@@ -12,6 +12,9 @@
  */
 package rajawali.postprocessing;
 
+import android.graphics.Bitmap.Config;
+import android.opengl.GLES20;
+
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -28,8 +31,6 @@ import rajawali.renderer.RajawaliRenderer;
 import rajawali.renderer.RenderTarget;
 import rajawali.scene.RajawaliScene;
 import rajawali.scenegraph.IGraphNode.GRAPH_TYPE;
-import android.graphics.Bitmap.Config;
-import android.opengl.GLES20;
 
 public class PostProcessingManager {
 
@@ -154,8 +155,8 @@ public class PostProcessingManager {
 	public void reset(RenderTarget renderTarget) {
 	}
 
-	public void render(double deltaTime) {
-		if(mComponentsDirty == true)
+	public void render(long ellapsedTime, double deltaTime) {
+		if(mComponentsDirty)
 		{
 			updatePassesList();
 			mComponentsDirty = false;
@@ -176,13 +177,13 @@ public class PostProcessingManager {
 			PassType type = pass.getPassType();
 			
 			pass.render(type == PassType.RENDER || type == PassType.DEPTH ? mRenderer.getCurrentScene() : mScene, mRenderer,
-					mScreenQuad, mWriteBuffer, mReadBuffer, deltaTime);
+					mScreenQuad, mWriteBuffer, mReadBuffer, ellapsedTime, deltaTime);
 
 			if (pass.needsSwap() && i < mNumPasses - 1) {
 				if (maskActive) {
 					GLES20.glStencilFunc(GLES20.GL_NOTEQUAL, 1, 0xffffffff);
 
-					mCopyPass.render(mScene, mRenderer, mScreenQuad, mWriteBuffer, mReadBuffer, deltaTime);
+					mCopyPass.render(mScene, mRenderer, mScreenQuad, mWriteBuffer, mReadBuffer, ellapsedTime, deltaTime);
 
 					GLES20.glStencilFunc(GLES20.GL_EQUAL, 1, 0xffffffff);
 				}

--- a/rajawali/src/main/java/rajawali/postprocessing/passes/ClearMaskPass.java
+++ b/rajawali/src/main/java/rajawali/postprocessing/passes/ClearMaskPass.java
@@ -12,12 +12,13 @@
  */
 package rajawali.postprocessing.passes;
 
+import android.opengl.GLES20;
+
 import rajawali.postprocessing.APass;
 import rajawali.primitives.ScreenQuad;
 import rajawali.renderer.RajawaliRenderer;
 import rajawali.renderer.RenderTarget;
 import rajawali.scene.RajawaliScene;
-import android.opengl.GLES20;
 
 /**
  * Disables stencil test for previously masked rendering passes so that
@@ -30,7 +31,7 @@ public class ClearMaskPass extends APass {
 	}
 	
 	@Override
-	public void render(RajawaliScene scene, RajawaliRenderer renderer, ScreenQuad screenQuad, RenderTarget writeBuffer, RenderTarget readBuffer, double deltaTime) {
+	public void render(RajawaliScene scene, RajawaliRenderer renderer, ScreenQuad screenQuad, RenderTarget writeBuffer, RenderTarget readBuffer, long ellapsedTime, double deltaTime) {
 		// Disable stencil test so next rendering pass won't be masked.
 		GLES20.glDisable(GLES20.GL_STENCIL_TEST);
 	}

--- a/rajawali/src/main/java/rajawali/postprocessing/passes/CopyToNewRenderTargetPass.java
+++ b/rajawali/src/main/java/rajawali/postprocessing/passes/CopyToNewRenderTargetPass.java
@@ -12,6 +12,9 @@
  */
 package rajawali.postprocessing.passes;
 
+import android.graphics.Bitmap.Config;
+import android.opengl.GLES20;
+
 import rajawali.framework.R;
 import rajawali.materials.textures.ATexture.FilterType;
 import rajawali.materials.textures.ATexture.WrapType;
@@ -19,8 +22,6 @@ import rajawali.primitives.ScreenQuad;
 import rajawali.renderer.RajawaliRenderer;
 import rajawali.renderer.RenderTarget;
 import rajawali.scene.RajawaliScene;
-import android.graphics.Bitmap.Config;
-import android.opengl.GLES20;
 
 public class CopyToNewRenderTargetPass extends EffectPass {
 	private RenderTarget mRenderTarget;
@@ -40,8 +41,8 @@ public class CopyToNewRenderTargetPass extends EffectPass {
 		return mRenderTarget;
 	}
 	
-	public void render(RajawaliScene scene, RajawaliRenderer renderer, ScreenQuad screenQuad, RenderTarget writeTarget, RenderTarget readTarget, double deltaTime) {
-		super.render(scene, renderer, screenQuad, mRenderTarget, readTarget, deltaTime);
+	public void render(RajawaliScene scene, RajawaliRenderer renderer, ScreenQuad screenQuad, RenderTarget writeTarget, RenderTarget readTarget, long ellapsedTime, double deltaTime) {
+		super.render(scene, renderer, screenQuad, mRenderTarget, readTarget, ellapsedTime, deltaTime);
 	}
 	
 	@Override

--- a/rajawali/src/main/java/rajawali/postprocessing/passes/DepthPass.java
+++ b/rajawali/src/main/java/rajawali/postprocessing/passes/DepthPass.java
@@ -34,12 +34,12 @@ public class DepthPass extends APass {
 	
 	@Override
 	public void render(RajawaliScene scene, RajawaliRenderer renderer, ScreenQuad screenQuad, RenderTarget writeTarget,
-			RenderTarget readTarget, double deltaTime) {
+			RenderTarget readTarget, long ellapsedTime, double deltaTime) {
 		GLES20.glClearColor(0, 0, 0, 1);
 		mDepthPlugin.setFarPlane((float)mCamera.getFarPlane());
 		mOldCamera = mScene.getCamera();
 		mScene.switchCamera(mCamera);
-		mScene.render(deltaTime, writeTarget, mMaterial);
+		mScene.render(ellapsedTime, deltaTime, writeTarget, mMaterial);
 		mScene.switchCamera(mOldCamera);
 	}
 }

--- a/rajawali/src/main/java/rajawali/postprocessing/passes/EffectPass.java
+++ b/rajawali/src/main/java/rajawali/postprocessing/passes/EffectPass.java
@@ -64,16 +64,16 @@ public class EffectPass extends APass {
 		mMaterial.bindTextureByName(PARAM_TEXTURE, 0, mReadTarget.getTexture());
 	}
 	
-	public void render(RajawaliScene scene, RajawaliRenderer renderer, ScreenQuad screenQuad, RenderTarget writeTarget, RenderTarget readTarget, double deltaTime) {
+	public void render(RajawaliScene scene, RajawaliRenderer renderer, ScreenQuad screenQuad, RenderTarget writeTarget, RenderTarget readTarget, long ellapsedTime, double deltaTime) {
 		mReadTarget = readTarget;
 		mWriteTarget = writeTarget;
 		screenQuad.setMaterial(mMaterial);
 		screenQuad.setEffectPass(this);
 		
-		if(mRenderToScreen == true)
-			scene.render(deltaTime, null);
+		if(mRenderToScreen)
+			scene.render(ellapsedTime, deltaTime, null);
 		else
-			scene.render(deltaTime, writeTarget);
+			scene.render(ellapsedTime, deltaTime, writeTarget);
 	}
 	
 	public void setOpacity(float value)

--- a/rajawali/src/main/java/rajawali/postprocessing/passes/MaskPass.java
+++ b/rajawali/src/main/java/rajawali/postprocessing/passes/MaskPass.java
@@ -15,12 +15,13 @@ package rajawali.postprocessing.passes;
 /**
  * Code heavily referenced from Three.js post processing framework.
  */
+import android.opengl.GLES20;
+
 import rajawali.postprocessing.APass;
 import rajawali.primitives.ScreenQuad;
 import rajawali.renderer.RajawaliRenderer;
 import rajawali.renderer.RenderTarget;
 import rajawali.scene.RajawaliScene;
-import android.opengl.GLES20;
 
 /**
  * Masked render pass for drawing to stencil buffer.
@@ -56,7 +57,7 @@ public class MaskPass extends APass {
 	}
 	
 	@Override
-	public void render(RajawaliScene scene, RajawaliRenderer render, ScreenQuad screenQuad, RenderTarget writeBuffer, RenderTarget readBuffer, double deltaTime) {
+	public void render(RajawaliScene scene, RajawaliRenderer render, ScreenQuad screenQuad, RenderTarget writeBuffer, RenderTarget readBuffer, long ellapsedTime, double deltaTime) {
 		// Do not update color or depth.
 		GLES20.glColorMask(false, false, false, false);
 		GLES20.glDepthMask(false);
@@ -78,8 +79,8 @@ public class MaskPass extends APass {
 		GLES20.glClearStencil(clearValue);
 		
 		// Draw into the stencil buffer.
-		mScene.render(deltaTime, readBuffer);
-		mScene.render(deltaTime, writeBuffer);
+		mScene.render(ellapsedTime, deltaTime, readBuffer);
+		mScene.render(ellapsedTime, deltaTime, writeBuffer);
 		
 		// Re-enable color and depth.
 		GLES20.glColorMask(true, true, true, true);

--- a/rajawali/src/main/java/rajawali/postprocessing/passes/RenderPass.java
+++ b/rajawali/src/main/java/rajawali/postprocessing/passes/RenderPass.java
@@ -12,14 +12,15 @@
  */
 package rajawali.postprocessing.passes;
 
+import android.graphics.Color;
+import android.opengl.GLES20;
+
 import rajawali.Camera;
 import rajawali.postprocessing.APass;
 import rajawali.primitives.ScreenQuad;
 import rajawali.renderer.RajawaliRenderer;
 import rajawali.renderer.RenderTarget;
 import rajawali.scene.RajawaliScene;
-import android.graphics.Color;
-import android.opengl.GLES20;
 
 /**
  * A render pass used for primarily rendering a scene to a framebuffer target.
@@ -50,7 +51,7 @@ public class RenderPass extends APass {
 		mNeedsSwap = true;
 	}
 	
-	public void render(RajawaliScene scene, RajawaliRenderer renderer, ScreenQuad screenQuad, RenderTarget writeBuffer, RenderTarget readBuffer, double deltaTime) {
+	public void render(RajawaliScene scene, RajawaliRenderer renderer, ScreenQuad screenQuad, RenderTarget writeBuffer, RenderTarget readBuffer, long ellapsedTime, double deltaTime) {
 		// Set the background color with that of current render pass.
 		if (mClearColor != 0x00000000) {
 			mOldClearColor = renderer.getCurrentScene().getBackgroundColor();
@@ -60,7 +61,7 @@ public class RenderPass extends APass {
 		// Render the current scene.
 		mOldCamera = mScene.getCamera();
 		mScene.switchCamera(mCamera);
-		mScene.render(deltaTime, mRenderToScreen == true ? null : writeBuffer, mMaterial);
+		mScene.render(ellapsedTime, deltaTime, mRenderToScreen ? null : writeBuffer, mMaterial);
 		mScene.switchCamera(mOldCamera);
 		
 		// Restore the old background color.

--- a/rajawali/src/main/java/rajawali/postprocessing/passes/ShadowPass.java
+++ b/rajawali/src/main/java/rajawali/postprocessing/passes/ShadowPass.java
@@ -35,15 +35,15 @@ public class ShadowPass extends RenderPass {
 	}
 	
 	@Override
-	public void render(RajawaliScene scene, RajawaliRenderer renderer, ScreenQuad screenQuad, RenderTarget writeBuffer, RenderTarget readBuffer, double deltaTime) {
+	public void render(RajawaliScene scene, RajawaliRenderer renderer, ScreenQuad screenQuad, RenderTarget writeBuffer, RenderTarget readBuffer, long ellapsedTime, double deltaTime) {
 		if(mShadowPassType == ShadowPassType.APPLY_SHADOW_MAP) {
 			mShadowMapMaterial.setShadowMapTexture(mShadowRenderTarget.getTexture());
-			super.render(scene, renderer, screenQuad, writeBuffer, readBuffer, deltaTime);
+			super.render(scene, renderer, screenQuad, writeBuffer, readBuffer, ellapsedTime, deltaTime);
 		} else {
 			int oldWidth = renderer.getCurrentViewportWidth();
 			int oldHeight = renderer.getCurrentViewportHeight();
 			renderer.setViewPort(mShadowMapSize, mShadowMapSize);
-			super.render(scene, renderer, screenQuad, mShadowRenderTarget, readBuffer, deltaTime);
+			super.render(scene, renderer, screenQuad, mShadowRenderTarget, readBuffer, ellapsedTime, deltaTime);
 			renderer.setViewPort(oldWidth, oldHeight);
 		}
 	}

--- a/rajawali/src/main/java/rajawali/renderer/AFrameTask.java
+++ b/rajawali/src/main/java/rajawali/renderer/AFrameTask.java
@@ -13,11 +13,12 @@
 package rajawali.renderer;
 
 
+import rajawali.scene.RajawaliScene;
 
 /**
  * This is an abstract class to extend for things which need to have
  * their addition/removal/modification in the scene properly regulated
- * by the {@link RajawaliRenderer} and OpenGL thread. 
+ * by the {@link RajawaliScene} and OpenGL thread.
  * 
  * @author Jared Woolston (jwoolston@tenkiv.com)
  */
@@ -48,7 +49,7 @@ public abstract class AFrameTask {
 	/**
 	 * The type of object this task is acting on.
 	 */
-	public enum TYPE {ANIMATION, CAMERA, LIGHT, OBJECT3D, PLUGIN, TEXTURE, SCENE, TEXTURE_MANAGER, COLOR_PICKER, MATERIAL, MATERIAL_MANAGER, RENDER_TARGET, EFFECT};
+	public enum TYPE {ANIMATION, CAMERA, LIGHT, OBJECT3D, PLUGIN, TEXTURE, SCENE, TEXTURE_MANAGER, COLOR_PICKER, MATERIAL, MATERIAL_MANAGER, RENDER_TARGET, EFFECT, FRAME_CALLBACK};
 	
 	private AFrameTask.TASK mFrameTask = AFrameTask.TASK.NONE; //The task to perform
 	private int mFrameTaskIndex = UNUSED_INDEX; //The index to replace, if relevant
@@ -73,7 +74,7 @@ public abstract class AFrameTask {
 	/**
 	 * Sets the task to be performed.
 	 * 
-	 * @param task {@AFrameTask.TASK} to be performed.
+	 * @param task {@link AFrameTask.TASK} to be performed.
 	 */
 	public void setTask(AFrameTask.TASK task) {
 		mFrameTask = task;
@@ -91,7 +92,7 @@ public abstract class AFrameTask {
 	/**
 	 * Sets the index this task acts on.
 	 * 
-	 * @param int The index.
+	 * @param index {@code int} The index.
 	 */
 	public void setIndex(int index) {
 		mFrameTaskIndex = index;

--- a/rajawali/src/main/java/rajawali/renderer/RajawaliSideBySideRenderer.java
+++ b/rajawali/src/main/java/rajawali/renderer/RajawaliSideBySideRenderer.java
@@ -12,6 +12,11 @@
  */
 package rajawali.renderer;
 
+import android.content.Context;
+import android.hardware.Sensor;
+import android.hardware.SensorEventListener;
+import android.opengl.GLES20;
+
 import rajawali.Camera;
 import rajawali.RajawaliActivity;
 import rajawali.materials.Material;
@@ -20,10 +25,6 @@ import rajawali.math.Quaternion;
 import rajawali.math.vector.Vector3.Axis;
 import rajawali.primitives.ScreenQuad;
 import rajawali.scene.RajawaliScene;
-import android.content.Context;
-import android.hardware.Sensor;
-import android.hardware.SensorEventListener;
-import android.opengl.GLES20;
 
 /**
  * <p>
@@ -225,7 +226,7 @@ public class RajawaliSideBySideRenderer extends RajawaliRenderer {
 	}
 
 	@Override
-	protected void onRender(final double deltaTime) {
+	protected void onRender(final long ellapsedTime, final double deltaTime) {
 		mUserScene = getCurrentScene();
 
 		setRenderTarget(mLeftRenderTarget);
@@ -234,7 +235,7 @@ public class RajawaliSideBySideRenderer extends RajawaliRenderer {
 		mCameraLeft.setProjectionMatrix(mViewportWidthHalf, mViewportHeight);
 		mCameraLeft.setOrientation(mCameraOrientation);
 
-		render(deltaTime);
+		render(ellapsedTime, deltaTime);
 
 		setRenderTarget(mRightRenderTarget);
 
@@ -242,14 +243,14 @@ public class RajawaliSideBySideRenderer extends RajawaliRenderer {
 		mCameraRight.setProjectionMatrix(mViewportWidthHalf, mViewportHeight);
 		mCameraRight.setOrientation(mCameraOrientation);
 
-		render(deltaTime);
+		render(ellapsedTime, deltaTime);
 
 		switchSceneDirect(mSideBySideScene);
 		GLES20.glViewport(0, 0, mViewportWidth, mViewportHeight);
 
 		setRenderTarget(null);
 
-		render(deltaTime);
+		render(ellapsedTime, deltaTime);
 
 		switchSceneDirect(mUserScene);
 	}

--- a/rajawali/src/main/java/rajawali/scene/ASceneFrameCallback.java
+++ b/rajawali/src/main/java/rajawali/scene/ASceneFrameCallback.java
@@ -1,0 +1,59 @@
+package rajawali.scene;
+
+import rajawali.renderer.AFrameTask;
+
+/**
+ * Abstract class for receiving frame callbacks from {@link RajawaliScene}. The timing
+ * of this interface assumes that the rendering time does not affect the timing of
+ * operations before and after the frame. Pre- and Post- operations are provided
+ * because of how these tie in with the animation system. Pre- tasks will be executed
+ * prior to animation updates. Post- tasks will be executed after all drawing has occurred.
+ *
+ * {@link #callPreFrame()} and {@link #callPostFrame()} frame exist to simplify interfacing
+ * to Rajawali's frame task system. By default they both return {@code false}, signalling that
+ * the callback should be ignored by the scene. Implementing classes must override these methods
+ * to return {@code true} as appropriate for the tasks they are handling.
+ *
+ * @author Jared Woolston (jwoolston@tenkiv.com)
+ */
+public abstract class ASceneFrameCallback extends AFrameTask {
+
+    /**
+     * Pre frame render callback. This will be called prior to any camera or animation updates in the scene.
+     *
+     * @param sceneTime {@code long} Rendering elapsed time in milliseconds.
+     * @param deltaTime {@code double} Time passed since last frame in seconds.
+     */
+    public abstract void onPreFrame(long sceneTime, double deltaTime);
+
+    /**
+     * Post frame render callback. Called after all frame drawing has completed, including plugins.
+     *
+     * @param sceneTime {@code long} Rendering elapsed time in milliseconds.
+     * @param deltaTime {@code double} Time passed since last frame in seconds.
+     */
+    public abstract void onPostFrame(long sceneTime, double deltaTime);
+
+    /**
+     * Should this be registered as a pre-frame callback.
+     *
+     * @return {@code boolean} True if this is a pre-frame callback implementation.
+     */
+    public boolean callPreFrame() {
+        return false;
+    }
+
+    /**
+     * Should this be registered as a post-frame callback.
+     *
+     * @return {@code boolean} True if this is a post-frame callback implementation.
+     */
+    public boolean callPostFrame() {
+        return false;
+    }
+
+    @Override
+    public TYPE getFrameTaskType() {
+        return TYPE.FRAME_CALLBACK;
+    }
+}

--- a/rajawali/src/main/java/rajawali/scene/RajawaliScene.java
+++ b/rajawali/src/main/java/rajawali/scene/RajawaliScene.java
@@ -93,6 +93,8 @@ public class RajawaliScene extends AFrameTask {
 	private ShadowMapMaterial mShadowMapMaterial;
 
 	private List<Object3D> mChildren;
+    private final List<ASceneFrameCallback> mPreCallbacks;
+    private final List<ASceneFrameCallback> mPostCallbacks;
 	private List<Animation> mAnimations;
 	private List<IRendererPlugin> mPlugins;
 	private List<ALight> mLights;
@@ -105,6 +107,7 @@ public class RajawaliScene extends AFrameTask {
 	*/
 	protected Camera mCamera;
 	private List<Camera> mCameras; //List of all cameras in the scene.
+
 	/**
 	* Temporary camera which will be switched to by the GL thread.
 	* Guarded by {@link #mNextCameraLock}
@@ -132,6 +135,8 @@ public class RajawaliScene extends AFrameTask {
 		mRenderer = renderer;
 		mAlpha = 0;
 		mAnimations = Collections.synchronizedList(new CopyOnWriteArrayList<Animation>());
+        mPreCallbacks = Collections.synchronizedList(new CopyOnWriteArrayList<ASceneFrameCallback>());
+        mPostCallbacks = Collections.synchronizedList(new CopyOnWriteArrayList<ASceneFrameCallback>());
 		mChildren = Collections.synchronizedList(new CopyOnWriteArrayList<Object3D>());
 		mPlugins = Collections.synchronizedList(new CopyOnWriteArrayList<IRendererPlugin>());
 		mCameras = Collections.synchronizedList(new CopyOnWriteArrayList<Camera>());
@@ -194,7 +199,7 @@ public class RajawaliScene extends AFrameTask {
 	/**
 	* Switches the {@link Camera} currently being used to display the scene.
 	* 
-	* @param mCamera {@link Camera} object to display the scene with.
+	* @param camera {@link Camera} object to display the scene with.
 	*/
 	public void switchCamera(Camera camera) {
 		synchronized (mNextCameraLock) {
@@ -276,7 +281,7 @@ public class RajawaliScene extends AFrameTask {
 	* 
 	* @param camera {@link Camera} object to add.
 	* @param location Integer index of the camera to replace.
-	* @param boolean True if the replacement was successfully queued.
+	* @return  boolean True if the replacement was successfully queued.
 	*/
 	public boolean replaceCamera(Camera camera, int location) {
 		return queueReplaceTask(location, camera);
@@ -290,7 +295,7 @@ public class RajawaliScene extends AFrameTask {
 	* 
 	* @param oldCamera {@link Camera} object to be replaced.
 	* @param newCamera {@link Camera} object replacing the old.
-	* @param boolean True if the replacement was successfully queued.
+	* @return  boolean True if the replacement was successfully queued.
 	*/
 	public boolean replaceCamera(Camera oldCamera, Camera newCamera) {
 		return queueReplaceTask(oldCamera, newCamera);
@@ -328,7 +333,7 @@ public class RajawaliScene extends AFrameTask {
 	* 
 	* @param oldCamera {@link Camera} object to be replaced.
 	* @param newCamera {@link Camera} object replacing the old.
-	* @param boolean True if the replacement was successfully queued.
+	* @return  boolean True if the replacement was successfully queued.
 	*/
 	public boolean replaceAndSwitchCamera(Camera oldCamera, Camera newCamera) {
 		boolean success = queueReplaceTask(oldCamera, newCamera);
@@ -431,8 +436,8 @@ public class RajawaliScene extends AFrameTask {
 	 * @param plugin {@link Plugin} child to be added.
 	 * @return True if the plugin was successfully queued for addition.
 	 */
-	public boolean addPlugin(Plugin plugins) {
-		return queueAddTask(plugins);
+	public boolean addPlugin(Plugin plugin) {
+		return queueAddTask(plugin);
 	}
 	
 	/**
@@ -517,6 +522,38 @@ public class RajawaliScene extends AFrameTask {
 	public boolean clearAnimations() {
 		return queueClearTask(AFrameTask.TYPE.ANIMATION);
 	}
+
+    /**
+     * Register a frame callback for this scene.
+     *
+     * @param callback {@link ASceneFrameCallback} to be registered.
+     *
+     * @return {@code boolean} True if the registration was queued successfully.
+     */
+    public boolean registerFrameCallback(ASceneFrameCallback callback) {
+        return queueAddTask(callback);
+    }
+
+    /**
+     * Remove a frame callback. If the callback is not a member of the scene,
+     * nothing will happen.
+     *
+     * @param callback {@link ASceneFrameCallback} to be unregistered.
+     *
+     * @return {@code boolean} True if the unregister was queued successfully.
+     */
+    public boolean unregisterFrameCallback(ASceneFrameCallback callback) {
+        return queueRemoveTask(callback);
+    }
+
+    /**
+     * Removes all {@link ASceneFrameCallback} objects from the scene.
+     *
+     * @return {@code boolean} True if the clear task was queued successfully.
+     */
+    public boolean clearFrameCallbacks() {
+        return queueClearTask(AFrameTask.TYPE.FRAME_CALLBACK);
+    }
 	
 	/**
 	 * Sets fog. 
@@ -663,11 +700,11 @@ public class RajawaliScene extends AFrameTask {
 		GLES20.glEnable(GLES20.GL_DEPTH_TEST);
 	}
 	
-	public void render(double deltaTime, RenderTarget renderTarget) {
-		render(deltaTime, renderTarget, null);
+	public void render(long ellapsedTime, double deltaTime, RenderTarget renderTarget) {
+		render(ellapsedTime, deltaTime, renderTarget, null);
 	}
 	
-	public void render(double deltaTime, RenderTarget renderTarget, Material sceneMaterial) {
+	public void render(long ellapsedTime, double deltaTime, RenderTarget renderTarget, Material sceneMaterial) {
 		performFrameTasks(); //Handle the task queue
 		if(mLightsDirty) {
 			updateMaterialsWithLights();
@@ -718,6 +755,17 @@ public class RajawaliScene extends AFrameTask {
 
 		GLES20.glClear(clearMask);
 
+        // Execute pre-render callbacks
+        // We explicitly break out the steps here to help the compiler optimize
+        final int preCount = mPreCallbacks.size();
+        if (preCount > 0) {
+            synchronized (mPreCallbacks) {
+                for (int i = 0; i < preCount; ++i) {
+                    mPreCallbacks.get(i).onPreFrame(ellapsedTime, deltaTime);
+                }
+            }
+        }
+
 		mVMatrix = mCamera.getViewMatrix();
 		mPMatrix = mCamera.getProjectionMatrix();
 		// Pre-multiply View and Projection matrices once for speed
@@ -747,7 +795,7 @@ public class RajawaliScene extends AFrameTask {
 					anim.update(deltaTime);
 			}
 		}
-		
+
 		Material sceneMat = pickerInfo == null ? sceneMaterial : pickerInfo.getPicker().getMaterial();
 		
 		if(sceneMat != null) {
@@ -794,7 +842,7 @@ public class RajawaliScene extends AFrameTask {
 			pickerInfo.getPicker().getRenderTarget().unbind();
 			pickerInfo = null;
 			mPickerInfo = null;
-			render(deltaTime, renderTarget, sceneMaterial); //TODO Possible timing error here
+			render(ellapsedTime, deltaTime, renderTarget, sceneMaterial); //TODO Possible timing error here
 		}
 
 		synchronized (mPlugins) {
@@ -806,6 +854,17 @@ public class RajawaliScene extends AFrameTask {
 		{
 			renderTarget.unbind();
 		}
+
+        // Execute post-render callbacks
+        // We explicitly break out the steps here to help the compiler optimize
+        final int postCount = mPostCallbacks.size();
+        if (postCount > 0) {
+            synchronized (mPostCallbacks) {
+                for (int i = 0; i < postCount; ++i) {
+                    mPostCallbacks.get(i).onPostFrame(ellapsedTime, deltaTime);
+                }
+            }
+        }
 	}
 	
 	/**
@@ -1033,6 +1092,8 @@ public class RajawaliScene extends AFrameTask {
 			break;
 		case PLUGIN:
 			internalAddPlugin((IRendererPlugin) task, task.getIndex());
+        case FRAME_CALLBACK:
+            internalAddFrameCallback((ASceneFrameCallback) task, task.getIndex());
 			break;
 		default:
 			break;
@@ -1062,6 +1123,9 @@ public class RajawaliScene extends AFrameTask {
 		case PLUGIN:
 			internalRemovePlugin((IRendererPlugin) task, task.getIndex());
 			break;
+        case FRAME_CALLBACK:
+            internalRemoveFrameCallback((ASceneFrameCallback) task);
+            break;
 		default:
 			break;
 		}
@@ -1173,6 +1237,12 @@ public class RajawaliScene extends AFrameTask {
 				}
 			}
 			break;
+        case FRAME_CALLBACK:
+            if (clear) {
+                internalClearFrameCallbacks();
+            } else {
+                //TODO: Implement if adding frame callback collections is added
+            }
 		default:
 			break;
 		}
@@ -1180,12 +1250,12 @@ public class RajawaliScene extends AFrameTask {
 	
 	/**
 	 * Internal method for replacing a {@link Animation} object. If index is
-	 * {@link AFrameTask.UNUSED_INDEX} then it will be used, otherwise the replace
+	 * {@link AFrameTask#UNUSED_INDEX} then it will be used, otherwise the replace
 	 * object is used. Should only be called through {@link #handleAddTask(AFrameTask)}
 	 * 
 	 * @param anim {@link AFrameTask} The old animation.
 	 * @param replace {@link Animation} The animation replacing the old animation.
-	 * @param index integer index to effect. Set to {@link AFrameTask.UNUSED_INDEX} if not used.
+	 * @param index integer index to effect. Set to {@link AFrameTask#UNUSED_INDEX} if not used.
 	 */
 	private void internalReplaceAnimation(AFrameTask anim, Animation replace, int index) {
 		if (index != AFrameTask.UNUSED_INDEX) {
@@ -1203,7 +1273,7 @@ public class RajawaliScene extends AFrameTask {
 	 * meaningless.
 	 * 
 	 * @param anim {@link Animation} to add.
-	 * @param int index to add the animation at. 
+	 * @param index int index to add the animation at.
 	 */
 	private void internalAddAnimation(Animation anim, int index) {
 		if (index == AFrameTask.UNUSED_INDEX) {
@@ -1212,7 +1282,7 @@ public class RajawaliScene extends AFrameTask {
 			mAnimations.add(index, anim);
 		}
 	}
-	
+
 	/**
 	 * Internal method for removing {@link Animation} objects.
 	 * Should only be called through {@link #handleRemoveTask(AFrameTask)}
@@ -1237,15 +1307,56 @@ public class RajawaliScene extends AFrameTask {
 	private void internalClearAnimations() {
 		mAnimations.clear();
 	}
-	
+
+    /**
+     * Internal method for adding {@link ASceneFrameCallback} objects.
+     * Should only be called through {@link #handleAddTask(AFrameTask)}
+     * <p/>
+     * This takes an index for the addition, but it is pretty
+     * meaningless.
+     *
+     * @param callback {@link ASceneFrameCallback} to add.
+     * @param index    int  index to add the animation at.
+     */
+    private void internalAddFrameCallback(ASceneFrameCallback callback, int index) {
+        if (index == AFrameTask.UNUSED_INDEX) {
+            if (callback.callPreFrame()) mPreCallbacks.add(callback);
+            if (callback.callPostFrame()) mPostCallbacks.add(callback);
+        } else {
+            if (callback.callPreFrame()) mPreCallbacks.add(index, callback);
+            if (callback.callPostFrame()) mPostCallbacks.add(index, callback);
+        }
+    }
+
+    /**
+     * Internal method for removing {@link ASceneFrameCallback} objects.
+     * Should only be called through {@link #handleRemoveTask(AFrameTask)}
+     * <p/>
+     *
+     * @param callback  {@link ASceneFrameCallback} to remove. If index is used, this is ignored.
+     */
+    private void internalRemoveFrameCallback(ASceneFrameCallback callback) {
+        if (callback.callPreFrame()) mPreCallbacks.remove(callback);
+        if (callback.callPostFrame()) mPostCallbacks.remove(callback);
+    }
+
+    /**
+     * Internal method for removing all {@link ASceneFrameCallback} objects.
+     * Should only be called through {@link #handleRemoveAllTask(AFrameTask)}
+     */
+    private void internalClearFrameCallbacks() {
+        mPreCallbacks.clear();
+        mPostCallbacks.clear();
+    }
+
 	/**
 	 * Internal method for replacing a {@link Camera}. If index is
-	 * {@link AFrameTask.UNUSED_INDEX} then it will be used, otherwise the replace
+	 * {@link AFrameTask#UNUSED_INDEX} then it will be used, otherwise the replace
 	 * object is used. Should only be called through {@link #handleReplaceTask(AFrameTask)}
 	 * 
 	 * @param camera {@link Camera} The old camera.
 	 * @param replace {@link Camera} The camera replacing the old camera.
-	 * @param index integer index to effect. Set to {@link AFrameTask.UNUSED_INDEX} if not used.
+	 * @param index integer index to effect. Set to {@link AFrameTask#UNUSED_INDEX} if not used.
 	 */
 	private void internalReplaceCamera(AFrameTask camera, Camera replace, int index) {
 		if (index != AFrameTask.UNUSED_INDEX) {
@@ -1264,7 +1375,7 @@ public class RajawaliScene extends AFrameTask {
 	 * meaningless.
 	 * 
 	 * @param camera {@link Camera} to add.
-	 * @param int index to add the camera at. 
+	 * @param index int index to add the camera at.
 	 */
 	private void internalAddCamera(Camera camera, int index) {
 		if (index == AFrameTask.UNUSED_INDEX) {
@@ -1341,13 +1452,13 @@ public class RajawaliScene extends AFrameTask {
 	}
 	
 	/**
-	 * Internal method for replacing a {@link ALightD} light. If index is
-	 * {@link AFrameTask.UNUSED_INDEX} then it will be used, otherwise the replace
+	 * Internal method for replacing a {@link ALight} light. If index is
+	 * {@link AFrameTask#UNUSED_INDEX} then it will be used, otherwise the replace
 	 * object is used. Should only be called through {@link #handleReplaceTask(AFrameTask)}
 	 * 
-	 * @param light {@link ALight} The new light for the specified index.
+	 * @param child {@link AFrameTask} The new light for the specified index.
 	 * @param replace {@link ALight} The light replacing the old light.
-	 * @param index integer index to effect. Set to {@link AFrameTask.UNUSED_INDEX} if not used.
+	 * @param index integer index to effect. Set to {@link AFrameTask#UNUSED_INDEX} if not used.
 	 */
 	private void internalReplaceLight(AFrameTask child, ALight replace, int index) {
 		if (index != AFrameTask.UNUSED_INDEX) {
@@ -1367,7 +1478,7 @@ public class RajawaliScene extends AFrameTask {
 	 * meaningless.
 	 * 
 	 * @param light {@link ALight} to add.
-	 * @param int index to add the light at. 
+	 * @param index int index to add the light at.
 	 */
 	private void internalAddLight(ALight light, int index) {
 		if (index == AFrameTask.UNUSED_INDEX) {
@@ -1480,12 +1591,12 @@ public class RajawaliScene extends AFrameTask {
 	
 	/**
 	 * Internal method for replacing a {@link Object3D} child. If index is
-	 * {@link AFrameTask.UNUSED_INDEX} then it will be used, otherwise the replace
+	 * {@link AFrameTask#UNUSED_INDEX} then it will be used, otherwise the replace
 	 * object is used. Should only be called through {@link #handleReplaceTask(AFrameTask)}
 	 * 
 	 * @param child {@link Object3D} The new child for the specified index.
 	 * @param replace {@link Object3D} The child replacing the old child.
-	 * @param index integer index to effect. Set to {@link AFrameTask.UNUSED_INDEX} if not used.
+	 * @param index integer index to effect. Set to {@link AFrameTask#UNUSED_INDEX} if not used.
 	 */
 	private void internalReplaceChild(AFrameTask child, Object3D replace, int index) {
 		if (index != AFrameTask.UNUSED_INDEX) {
@@ -1504,7 +1615,7 @@ public class RajawaliScene extends AFrameTask {
 	 * meaningless.
 	 * 
 	 * @param child {@link Object3D} to add.
-	 * @param int index to add the child at. 
+	 * @param index int index to add the child at.
 	 */
 	private void internalAddChild(Object3D child, int index) {
 		if (index == AFrameTask.UNUSED_INDEX) {
@@ -1583,12 +1694,12 @@ public class RajawaliScene extends AFrameTask {
 
 	/**
 	 * Internal method for replacing a {@link IRendererPlugin}. If index is
-	 * {@link AFrameTask.UNUSED_INDEX} then it will be used, otherwise the replace
+	 * {@link AFrameTask#UNUSED_INDEX} then it will be used, otherwise the replace
 	 * object is used. Should only be called through {@link #handleReplaceTask(AFrameTask)}
 	 * 
 	 * @param plugin {@link IRendererPlugin} The new plugin for the specified index.
 	 * @param replace {@link IRendererPlugin} The plugin replacing the old plugin.
-	 * @param index integer index to effect. Set to {@link AFrameTask.UNUSED_INDEX} if not used.
+	 * @param index integer index to effect. Set to {@link AFrameTask#UNUSED_INDEX} if not used.
 	 */
 	private void internalReplacePlugin(AFrameTask plugin, IRendererPlugin replace, int index) {
 		if (index != AFrameTask.UNUSED_INDEX) {
@@ -1606,7 +1717,7 @@ public class RajawaliScene extends AFrameTask {
 	 * meaningless.
 	 * 
 	 * @param plugin {@link IRendererPlugin} to add.
-	 * @param int index to add the child at. 
+	 * @param index int index to add the child at.
 	 */
 	private void internalAddPlugin(IRendererPlugin plugin, int index) {
 		if (index == AFrameTask.UNUSED_INDEX) {


### PR DESCRIPTION
Allows user code to register for pre- frame and post-frame callbacks. These callbacks receive not only the frame delta time, but also the elapsed render time in nanoseconds, allowing for more complex physics and animations in an easy to plugin fashion. Implementations can register for pre only, post only or both callbacks.

Signed-off-by: Jared Woolston <jwoolston@tenkiv.com>